### PR TITLE
Specialized &. operator for use with ClassName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 Breaking changes:
 
 New features:
+- A specialized version of the `&.` operator has been added for use with
+  Halogen's `ClassName` type.
 
 Bugfixes:
 

--- a/src/Tecton/Halogen.purs
+++ b/src/Tecton/Halogen.purs
@@ -1,36 +1,3 @@
-module Tecton.Halogen (style, styleSheet) where
+module Tecton.Halogen (module X) where
 
-import Prelude
-
-import Control.Monad.Writer (Writer)
-import Data.List (List)
-import Halogen.HTML.Core as HC
-import Halogen.HTML.Elements as HE
-import Halogen.HTML.Properties as HP
-import Tecton (CSS)
-import Tecton.Internal (Declaration', pretty, renderInline, renderSheet)
-
--- | Renders declarations as an inline style, e.g.
--- | ```purescript
--- | HH.header
--- |   [ CSS.style Rule.do
--- |       width := pct 100
--- |       height := px 64
--- |   ]
--- |   [ ... ]
--- | ```
-style
-  :: forall ps p i
-   . Writer (List Declaration') ps
-  -> HP.IProp (style :: String | p) i
-style = HP.attr (HC.AttrName "style") <<< renderInline
-
--- | Creates a `style` element with the specified style sheet rendered as its
--- | text content.
-styleSheet :: forall p i. CSS -> HC.HTML p i
-styleSheet =
-  HE.style_
-    <<< pure
-    <<< HC.text
-    <<< (\s -> "\n" <> s <> "\n")
-    <<< renderSheet pretty
+import Tecton.Halogen.Internal (style, styleSheet, (&.)) as X

--- a/src/Tecton/Halogen/Internal.purs
+++ b/src/Tecton/Halogen/Internal.purs
@@ -1,0 +1,50 @@
+module Tecton.Halogen.Internal ((&.), byClass, style, styleSheet) where
+
+import Prelude
+
+import Control.Monad.Writer (Writer)
+import Data.List (List)
+import Halogen (ClassName(..))
+import Halogen.HTML.Core as HC
+import Halogen.HTML.Elements as HE
+import Halogen.HTML.Properties as HP
+import Tecton (CSS)
+import Tecton.Internal (class IsExtensibleSelector, class ToVal, Declaration', Extensible, Selector, pretty, renderInline, renderSheet)
+import Tecton.Internal as T
+
+-- | Appends a class name to the end of a selector.
+byClass
+  :: forall selector
+   . IsExtensibleSelector selector
+  => ToVal selector
+  => selector
+  -> ClassName
+  -> Selector Extensible
+byClass s (ClassName c) = T.byClass s c
+
+infixl 7 byClass as &.
+
+-- | Renders declarations as an inline style, e.g.
+-- | ```purescript
+-- | HH.header
+-- |   [ CSS.style Rule.do
+-- |       width := pct 100
+-- |       height := px 64
+-- |   ]
+-- |   [ ... ]
+-- | ```
+style
+  :: forall ps p i
+   . Writer (List Declaration') ps
+  -> HP.IProp (style :: String | p) i
+style = HP.attr (HC.AttrName "style") <<< renderInline
+
+-- | Creates a `style` element with the specified style sheet rendered as its
+-- | text content.
+styleSheet :: forall p i. CSS -> HC.HTML p i
+styleSheet =
+  HE.style_
+    <<< pure
+    <<< HC.text
+    <<< (\s -> "\n" <> s <> "\n")
+    <<< renderSheet pretty

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,11 +4,12 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Aff (launchAff_)
+import Halogen (ClassName(..))
 import Halogen.HTML as HH
 import Halogen.VDom.DOM.StringRenderer (render)
 import Tecton (all, display, height, inlineBlock, media, padding, pct, px, width, (:=), (?))
 import Tecton as T
-import Tecton.Halogen (style, styleSheet)
+import Tecton.Halogen (style, styleSheet, (&.))
 import Tecton.Rule as Rule
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
@@ -40,7 +41,7 @@ main =
           let
             HH.HTML el =
               styleSheet do
-                T.header ? Rule.do
+                T.header &. ClassName "masthead" ? Rule.do
                   width := pct 100
                   height := px 64
                 media all { minWidth: px 1280 } ?
@@ -50,7 +51,7 @@ main =
             render identity el
               `shouldEqual`
               """<style>
-header {
+header.masthead {
   width: 100%;
   height: 64px;
 }


### PR DESCRIPTION
### Description

This PR adds a new `&.` operator that can be imported from `Tecton.Halogen` instead of `Tecton`. It will accept a `ClassName` instead of a `String`, saving the user from having to unwrap the `ClassName` which could otherwise add a lot of noise.

### Design considerations

After sharing https://github.com/purescript-halogen/purescript-halogen/issues/805#issuecomment-1324274232, I realized I could address the need for something like an `unClassName` utility by simply providing an alternate version of Tecton's `&.` operator, hence this PR.

### Future plans

N/A

### References

* https://github.com/purescript-halogen/purescript-halogen/issues/805#issuecomment-1324274232
* [Halogen `ClassName` type](https://pursuit.purescript.org/packages/purescript-halogen/6.1.2/docs/Halogen#t:ClassName)
* [Tecton `&.` operator](https://github.com/nsaunders/purescript-tecton/blob/01b7498a8cda15908365547de9dd67c46ec30d43/src/Tecton/Internal.purs#L5981-L5990)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting and run the unit tests.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
