### PR TITLE
Drop `&.` operator which is now redundant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 ## [Unreleased]
 
 Breaking changes:
+- Dropped the `&.` operator. Import it from the `Tecton` module instead. nsaunders/purescript-tecton-halogen#3
 
 New features:
 

--- a/src/Tecton/Halogen.purs
+++ b/src/Tecton/Halogen.purs
@@ -1,3 +1,3 @@
 module Tecton.Halogen (module X) where
 
-import Tecton.Halogen.Internal (style, styleSheet, (&.)) as X
+import Tecton.Halogen.Internal (style, styleSheet) as X

--- a/src/Tecton/Halogen/Internal.purs
+++ b/src/Tecton/Halogen/Internal.purs
@@ -1,28 +1,14 @@
-module Tecton.Halogen.Internal ((&.), byClass, style, styleSheet) where
+module Tecton.Halogen.Internal (style, styleSheet) where
 
 import Prelude
 
 import Control.Monad.Writer (Writer)
 import Data.List (List)
-import Halogen (ClassName(..))
 import Halogen.HTML.Core as HC
 import Halogen.HTML.Elements as HE
 import Halogen.HTML.Properties as HP
 import Tecton (CSS)
-import Tecton.Internal (class IsExtensibleSelector, class ToVal, Declaration', Extensible, Selector, pretty, renderInline, renderSheet)
-import Tecton.Internal as T
-
--- | Appends a class name to the end of a selector.
-byClass
-  :: forall selector
-   . IsExtensibleSelector selector
-  => ToVal selector
-  => selector
-  -> ClassName
-  -> Selector Extensible
-byClass s (ClassName c) = T.byClass s c
-
-infixl 7 byClass as &.
+import Tecton.Internal (Declaration', pretty, renderInline, renderSheet)
 
 -- | Renders declarations as an inline style, e.g.
 -- | ```purescript

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,9 +7,9 @@ import Effect.Aff (launchAff_)
 import Halogen (ClassName(..))
 import Halogen.HTML as HH
 import Halogen.VDom.DOM.StringRenderer (render)
-import Tecton (all, display, height, inlineBlock, media, padding, pct, px, width, (:=), (?))
+import Tecton (all, display, height, inlineBlock, media, padding, pct, px, width, (&.), (:=), (?))
 import Tecton as T
-import Tecton.Halogen (style, styleSheet, (&.))
+import Tecton.Halogen (style, styleSheet)
 import Tecton.Rule as Rule
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)


### PR DESCRIPTION
### Description

With this change, the `&.` is dropped (meaning no longer exported from `Tecton.Halogen`), in favor of the `&.` operator exported from the `Tecton` module.

This follows nsaunders/purescript-tecton#35 where the core library's `&.` operator was updated to work with the [`ClassName` type from web-html](https://pursuit.purescript.org/packages/purescript-web-html/4.1.0/docs/Web.HTML.Common#t:ClassName). As it turns out, Halogen's `ClassName` type is just a re-export of this type, meaning the `&.` operator exported from `Tecton` is essentially the same as the one that is being removed from `Tecton.Halogen`.

### Design considerations

N/A

### Future plans

N/A

### References

N/A (already linked above)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting and run the unit tests.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
